### PR TITLE
Add flag for routine only tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
             toxenv: py312
           - python-version: "3.13"
             toxenv: py313
-
+          - python-version: "3.14"
+            toxenv: py313
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - python-version: "3.13"
             toxenv: py313
           - python-version: "3.14"
-            toxenv: py313
+            toxenv: py314
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -23,8 +23,9 @@ jobs:
             toxenv: py312
           - python-version: "3.13"
             toxenv: py313
-          - python-version: "3.14"
+          - python-version: "3.14.0-rc.1"
             toxenv: py314
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,6 +34,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install tox
         run: |
@@ -53,7 +55,7 @@ jobs:
 
   quality:
     name: Code Quality & Security
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test
 
     steps:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
 include LICENSE
-include example.py
+recursive-include examples *.py
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co] 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Python debugging library for detailed code execution tracing. This library pro
 ## Features
 
 - **Line-by-line execution tracing**: See exactly which lines are being executed
+- **Function/method call tracing**: Trace only function and method calls without line details
 - **Variable value inspection**: View the values of variables at each execution step
 - **Module filtering**: Trace only specific modules or all modules
 - **Context manager support**: Use with `with` statements for automatic cleanup
@@ -100,17 +101,38 @@ with SpewContext(show_values=False):
     result = my_function()
 ```
 
+### Function-Only Tracing
+
+```python
+from spewer import SpewContext
+
+# Trace only function/method calls without line details
+with SpewContext(functions_only=True, show_values=True):
+    def my_function(x, y):
+        result = x + y
+        return result
+    
+    result = my_function(10, 20)
+```
+
+This will output:
+```
+__main__:15: my_function()
+    args: x=10, y=20
+```
+
 ## API Reference
 
 ### Functions
 
-#### `spew(trace_names=None, show_values=False)`
+#### `spew(trace_names=None, show_values=False, functions_only=False)`
 
 Install a trace hook which writes detailed logs about code execution.
 
 **Parameters:**
 - `trace_names` (Optional[List[str]]): List of module names to trace. If None, traces all modules.
 - `show_values` (bool): Whether to show variable values during tracing.
+- `functions_only` (bool): Whether to trace only function/method calls instead of line-by-line execution.
 
 #### `unspew()`
 
@@ -118,21 +140,23 @@ Remove the trace hook installed by `spew()`.
 
 ### Classes
 
-#### `Spewer(trace_names=None, show_values=True)`
+#### `Spewer(trace_names=None, show_values=True, functions_only=False)`
 
 A trace hook class that provides detailed debugging information.
 
 **Parameters:**
 - `trace_names` (Optional[List[str]]): List of module names to trace. If None, traces all modules.
 - `show_values` (bool): Whether to show variable values during tracing.
+- `functions_only` (bool): Whether to trace only function/method calls instead of line-by-line execution.
 
-#### `SpewContext(trace_names=None, show_values=False)`
+#### `SpewContext(trace_names=None, show_values=False, functions_only=False)`
 
 Context manager for automatic spew/unspew operations.
 
 **Parameters:**
 - `trace_names` (Optional[List[str]]): List of module names to trace. If None, traces all modules.
 - `show_values` (bool): Whether to show variable values during tracing.
+- `functions_only` (bool): Whether to trace only function/method calls instead of line-by-line execution.
 
 ## Example Output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spewer"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Python debugging library for detailed code execution tracing"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dev = [
     "ruff>=0.12.7"
 ]
 
-[tool.setuptools]
-py-modules = ["spewer"]
+[tool.setuptools.packages.find]
+where = ["."]
 
 
 [tool.ruff]

--- a/spewer/spewer.py
+++ b/spewer/spewer.py
@@ -15,74 +15,77 @@ class Spewer:
     """A trace hook class that provides detailed debugging information."""
 
     def __init__(
-        self, trace_names: Optional[list[str]] = None, show_values: bool = True, functions_only: bool = False
+        self,
+        trace_names: Optional[list[str]] = None,
+        show_values: bool = True,
+        functions_only: bool = False,
     ):
         """Initialize the Spewer."""
         self.trace_names = trace_names
         self.show_values = show_values
         self.functions_only = functions_only
+        if not isinstance(trace_names, (list, type(None))):
+            msg = "trace_names must be a list or None"
+            raise TypeError(msg)
 
-    def __call__(self, frame: Any, event: str, arg: Any) -> Spewer:
-        """Trace hook callback that processes execution events."""
-        if self.functions_only and event == "call":
-            # Handle function/method calls only
-            lineno = frame.f_lineno
-            func_name = frame.f_code.co_name
-            
-            # Get filename and handle compiled files
-            if "__file__" in frame.f_globals:
-                filename = frame.f_globals["__file__"]
-                if filename.endswith((".pyc", ".pyo")):
-                    filename = filename[:-1]
-                name = frame.f_globals["__name__"]
-            else:
-                name = "[unknown]"
-                filename = "[unknown]"
+    def _handle_function_call(self, frame: Any) -> None:
+        """Handle function call events."""
+        lineno = frame.f_lineno
+        func_name = frame.f_code.co_name
 
-            # Check if we should trace this module
-            if self.trace_names is None or name in self.trace_names:
-                print(f"{name}:{lineno}: {func_name}()")
+        # Get filename and handle compiled files
+        if "__file__" in frame.f_globals:
+            filename = frame.f_globals["__file__"]
+            if filename.endswith((".pyc", ".pyo")):
+                filename = filename[:-1]
+            name = frame.f_globals["__name__"]
+        else:
+            name = "[unknown]"
+            filename = "[unknown]"
 
-                if self.show_values:
-                    # Show function arguments if available
-                    if frame.f_locals:
-                        args = []
-                        for key, value in frame.f_locals.items():
-                            if not key.startswith('__'):
-                                try:
-                                    args.append(f"{key}={value!r}")
-                                except (AttributeError, TypeError, RecursionError):
-                                    args.append(f"{key}=<{type(value).__name__} object>")
-                        if args:
-                            print(f"\targs: {', '.join(args)}")
+        # Check if we should trace this module
+        if self.trace_names is None or name in self.trace_names:
+            print(f"{name}:{lineno}: {func_name}()")
 
-        elif not self.functions_only and event == "line":
-            # Handle line-by-line tracing (original behavior)
-            lineno = frame.f_lineno
+            if not self.show_values:
+                return
+            if frame.f_locals:
+                args = []
+                for key, value in frame.f_locals.items():
+                    if not key.startswith("__"):
+                        try:
+                            args.append(f"{key}={value!r}")
+                        except (AttributeError, TypeError, RecursionError):
+                            args.append(f"{key}=<{type(value).__name__} object>")
+                if args:
+                    print(f"\targs: {', '.join(args)}")
 
-            # Get filename and handle compiled files
-            if "__file__" in frame.f_globals:
-                filename = frame.f_globals["__file__"]
-                if filename.endswith((".pyc", ".pyo")):
-                    filename = filename[:-1]
-                name = frame.f_globals["__name__"]
-                line = linecache.getline(filename, lineno)
-            else:
-                name = "[unknown]"
-                try:
-                    src = inspect.getsourcelines(frame)
-                    line = src[lineno]
-                except OSError:
-                    line = f"Unknown code named [{frame.f_code.co_name}]. VM instruction #{frame.f_lasti}"
+    def _handle_line_by_line(self, frame: Any) -> None:
+        """Handle line-by-line tracing."""
+        lineno = frame.f_lineno
+        # Get filename and handle compiled files
+        if "__file__" in frame.f_globals:
+            filename = frame.f_globals["__file__"]
+            if filename.endswith((".pyc", ".pyo")):
+                filename = filename[:-1]
+            name = frame.f_globals["__name__"]
+            line = linecache.getline(filename, lineno)
+        else:
+            name = "[unknown]"
+            try:
+                src = inspect.getsourcelines(frame)
+                line = src[lineno]
+            except OSError:
+                line = f"Unknown code named [{frame.f_code.co_name}]. VM instruction #{frame.f_lasti}"
 
-            # Check if we should trace this module
-            if self.trace_names is None or name in self.trace_names:
-                print(f"{name}:{lineno}: {line.rstrip()}")
+        # Check if we should trace this module
+        if self.trace_names is None or name in self.trace_names:
+            print(f"{name}:{lineno}: {line.rstrip()}")
+            if not self.show_values:
+                return
 
-                if not self.show_values:
-                    return self
-
-                # Show variable values
+            # Show function arguments if available
+            if frame.f_locals:
                 details = []
                 tokens = _token_splitter.split(line)
 
@@ -93,16 +96,29 @@ class Spewer:
                         if tok in frame.f_locals:
                             details.append(f"{tok}={frame.f_locals[tok]!r}")
                     except (AttributeError, TypeError, RecursionError):
-                        # TODO: explore how to handle this better
                         pass
 
                 if details:
-                    print(f"\t{' '.join(details)}")
+                    print(f"\t{', '.join(details)}")
+
+    def __call__(self, frame: Any, event: str, arg: Any) -> Spewer:
+        """Trace hook callback that processes execution events."""
+        if self.functions_only and event == "call":
+            # Handle function call events
+            self._handle_function_call(frame)
+
+        elif not self.functions_only and event == "line":
+            # Handle line-by-line tracing
+            self._handle_line_by_line(frame)
 
         return self
 
 
-def spew(trace_names: Optional[list[str]] = None, show_values: bool = False, functions_only: bool = False) -> None:
+def spew(
+    trace_names: Optional[list[str]] = None,
+    show_values: bool = False,
+    functions_only: bool = False,
+) -> None:
     """Install a trace hook for detailed code execution logging."""
     sys.settrace(Spewer(trace_names, show_values, functions_only))
 
@@ -116,7 +132,10 @@ class SpewContext:
     """Context manager for automatic spew/unspew operations."""
 
     def __init__(
-        self, trace_names: Optional[list[str]] = None, show_values: bool = False, functions_only: bool = False
+        self,
+        trace_names: Optional[list[str]] = None,
+        show_values: bool = False,
+        functions_only: bool = False,
     ):
         self.trace_names = trace_names
         self.show_values = show_values

--- a/tests/test_spewer.py
+++ b/tests/test_spewer.py
@@ -39,6 +39,24 @@ class TestSpewer:
         result = spewer(frame, "line", None)
         assert result is spewer
 
+    def test_spewer_call_with_function_event(self):
+        """Test Spewer __call__ method with function event."""
+        spewer = Spewer(show_values=True, functions_only=True)
+
+        # Create a mock frame
+        class MockFrame:
+            def __init__(self):
+                self.f_lineno = 20
+                self.f_globals = {"__file__": "test.py", "__name__": "test"}
+                self.f_locals = {"arg1": 42, "arg2": "hello"}
+                self.f_code = type(
+                    "MockCode", (), {"co_name": "test_func", "co_lasti": 0}
+                )()
+
+        frame = MockFrame()
+        result = spewer(frame, "call", None)
+        assert result is spewer
+
     def test_spewer_call_with_other_event(self):
         """Test Spewer __call__ method with non-line event."""
         spewer = Spewer()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, py313, lint, format
+envlist = py39, py310, py311, py312, py313,py140, lint, format
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, py313,py140, lint, format
+envlist = py39, py310, py311, py312, py313,py314, lint, format
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
fixes #1

<!-- greptile_comment -->

## Greptile Summary

This PR adds a new `functions_only` flag to the Spewer debugging library that enables function-only tracing mode. When enabled, this flag causes the tracer to capture only function and method calls instead of the default line-by-line execution tracing. The feature addresses issue #1 by providing a less verbose debugging option for users who want to understand program flow without getting overwhelmed by detailed line-by-line output.

The implementation adds the `functions_only` parameter (defaulting to `False`) to all public APIs: the `Spewer` class constructor, the `spew()` function, and the `SpewContext` class. When `functions_only=True`, the trace hook handles 'call' events instead of 'line' events, displaying function names with module information and optionally showing function arguments when `show_values=True`. The feature maintains full backward compatibility and integrates seamlessly with existing functionality like module filtering (`trace_names`) and value display options.

The change follows the library's existing patterns for error handling, output formatting, and module filtering. The README.md has been comprehensively updated with examples demonstrating the new functionality and complete API reference documentation for the new parameter across all relevant functions and classes.

## Important Files Changed

<details>
<summary>Click to expand file changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `spewer/spewer.py` | 4/5 | Adds functions_only parameter to all APIs and implements function-call-only tracing logic with proper argument handling |
| `README.md` | 4/5 | Updates documentation with examples and API reference for the new functions_only parameter, but contains a line number discrepancy in example output |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds an optional feature with backward compatibility
- Score reflects well-structured implementation following existing patterns, though the new tracing logic adds some complexity and there's a documentation inconsistency
- Pay close attention to the trace hook logic in `spewer/spewer.py` to ensure proper event handling and fix the line number mismatch in README.md examples

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Spewer
    participant "sys.settrace"
    participant Frame
    participant Output

    User->>+Spewer: "spew(functions_only=True)"
    Spewer->>Spewer: "__init__(functions_only=True)"
    Spewer->>+"sys.settrace": "Install trace hook"
    
    User->>User: "Execute code with function calls"
    
    loop For each function call
        Frame->>"sys.settrace": "Trigger 'call' event"
        "sys.settrace"->>+Spewer: "__call__(frame, 'call', arg)"
        
        alt functions_only is True
            Spewer->>Spewer: "Extract function name and line number"
            Spewer->>Spewer: "Check module filtering (trace_names)"
            
            alt Module should be traced
                Spewer->>Output: "Print function call info"
                
                alt show_values is True
                    Spewer->>Frame: "Get function arguments from f_locals"
                    Spewer->>Output: "Print function arguments"
                end
            end
        end
        
        Spewer-->>-Spewer: "Return self for continued tracing"
    end
    
    User->>+Spewer: "unspew()"
    Spewer->>-"sys.settrace": "Remove trace hook (None)"
```

<!-- /greptile_comment -->